### PR TITLE
Portf 827 unified bsp h merge master netsnmp changes

### DIFF
--- a/package/netsnmp/0001_netsnmp-002-agent.patch
+++ b/package/netsnmp/0001_netsnmp-002-agent.patch
@@ -1,31 +1,28 @@
---- netsnmp-5.4.2.1_orig/agent/agent_trap.c.orig	2022-05-26 14:33:57.975843799 +0300
-+++ netsnmp-5.4.2.1_new/agent/agent_trap.c	2012-09-09 12:43:33.886695990 +0300
-@@ -62,6 +62,12 @@
+--- netsnmp-5.9_orig/agent/agent_trap.c.orig	2020-08-15 00:41:47.000000000 +0300
++++ netsnmp-5.9_new/agent/agent_trap.c	2022-06-02 07:52:48.489844624 +0300
+@@ -62,6 +62,10 @@
  #include <net-snmp/agent/agent_trap.h>
  #include <net-snmp/agent/snmp_agent.h>
  #include <net-snmp/agent/agent_callbacks.h>
-+// Alan add
 +#include <net-snmp/agent/agent_handler.h>
 +#include <net-snmp/library/snmp_api.h>
 +#include <net-snmp/library/snmp_client.h>
 +#include <net-snmp/library/fd_event_manager.h>
-+// End Alan add
  #include "agent_global_vars.h"
  
  #include <net-snmp/agent/agent_module_config.h>
-@@ -88,6 +94,7 @@
+@@ -88,6 +92,7 @@
      struct trap_sink *next;
      int             pdutype;
      int             version;
-+	u_char			my_data[60]; // Alan add
++	u_char			my_data[60];
  };
  
  struct trap_sink *sinks = NULL;
-@@ -145,6 +152,29 @@
+@@ -145,6 +150,26 @@
  	 * Trap session handling
  	 *
  	 *******************/
-+// Alan add
 +int GetNumOfSinks( void)
 +{
 +    struct trap_sink *sink;
@@ -46,45 +43,37 @@
 +
 +volatile oid myEnterpriseOid[50];
 +volatile int myEnterpriseOidLen = 0;
-+
-+// End Alan add
  
  void
  init_traps(void)
-@@ -835,6 +865,12 @@
+@@ -835,6 +860,10 @@
      in_addr_t             *pdu_in_addr_t;
      u_long                 uptime;
      struct trap_sink *sink;
 +
-+// Alan add
 +	enterprise = myEnterpriseOid;
 +	enterprise_length = myEnterpriseOidLen;
-+// End Alan add
 +
      const char            *v1trapaddress;
      int                    res = 0;
  
-@@ -1025,13 +1061,30 @@
+@@ -1025,13 +1054,24 @@
              if (template_v1pdu &&
                  !netsnmp_ds_get_boolean(NETSNMP_DS_LIBRARY_ID,
                                          NETSNMP_DS_LIB_DISABLE_V1)) {
 -                send_trap_to_sess(sink->sesp, template_v1pdu);
-+// Alan add
 +			    int toDo = 1;
 +			    if(myBeforeSendTrapPtr != NULL)
 +			    	toDo = myBeforeSendTrapPtr( sink->my_data, sink->sesp, template_v1pdu);
 +
 +			    if(toDo != 0)
 +                	send_trap_to_sess(sink->sesp, template_v1pdu);
-+// End Alan add
-+                //send_trap_to_sess(sink->sesp, template_v1pdu); // Alan remove
              }
          } else
  #endif
          if (template_v2pdu) {
              template_v2pdu->command = sink->pdutype;
 -            send_trap_to_sess(sink->sesp, template_v2pdu);
-+// Alan add
 +
 +			    int toDo = 1;
 +			    if(myBeforeSendTrapPtr != NULL)
@@ -92,25 +81,21 @@
 +
 +			    if(toDo != 0)
 +	                send_trap_to_sess(sink->sesp, template_v2pdu);
-+// End Alan add
-+            // send_trap_to_sess(sink->sesp, template_v2pdu); // Alan remove
          }
      }
  #ifndef NETSNMP_DISABLE_SNMPV1
---- netsnmp-5.4.2.1_orig/agent/snmpd.c.orig	2008-08-17 23:50:55.000000000 +0300
-+++ netsnmp-5.4.2.1_new/agent/snmpd.c	2012-09-09 12:41:15.250695993 +0300
-@@ -405,6 +405,14 @@
+--- netsnmp-5.9_orig/agent/snmpd.c	2020-08-15 00:41:47.000000000 +0300
++++ netsnmp-5.9-new/agent/snmpd.c	2022-06-02 07:53:36.322894405 +0300
+@@ -405,6 +405,12 @@
      FILE           *PID;
  #endif
  
-+// Alan add
 +    /* !!! DO NOT DELETE THE FOLLOWING 2 LINES !!! */ 
 +    extern GetNumOfSinks(), AddMyDataToLastSink();
 +    printf("%p %p %p %p %p %p %p %p\n", GetNumOfSinks, AddMyDataToLastSink,
 +    		snmp_add_var, netsnmp_unregister_handler,
 +    		snmp_unregister_callback, snmp_set_var_typed_integer,
 +		register_readfd, unregister_readfd);
-+// End Alan add
      SOCK_STARTUP;
  
  #ifndef NETSNMP_NO_SYSTEMD

--- a/package/netsnmp/0001_netsnmp-002-agent.patch
+++ b/package/netsnmp/0001_netsnmp-002-agent.patch
@@ -1,0 +1,116 @@
+--- netsnmp-5.4.2.1_orig/agent/agent_trap.c.orig	2022-05-26 14:33:57.975843799 +0300
++++ netsnmp-5.4.2.1_new/agent/agent_trap.c	2012-09-09 12:43:33.886695990 +0300
+@@ -62,6 +62,12 @@
+ #include <net-snmp/agent/agent_trap.h>
+ #include <net-snmp/agent/snmp_agent.h>
+ #include <net-snmp/agent/agent_callbacks.h>
++// Alan add
++#include <net-snmp/agent/agent_handler.h>
++#include <net-snmp/library/snmp_api.h>
++#include <net-snmp/library/snmp_client.h>
++#include <net-snmp/library/fd_event_manager.h>
++// End Alan add
+ #include "agent_global_vars.h"
+ 
+ #include <net-snmp/agent/agent_module_config.h>
+@@ -88,6 +94,7 @@
+     struct trap_sink *next;
+     int             pdutype;
+     int             version;
++	u_char			my_data[60]; // Alan add
+ };
+ 
+ struct trap_sink *sinks = NULL;
+@@ -145,6 +152,29 @@
+ 	 * Trap session handling
+ 	 *
+ 	 *******************/
++// Alan add
++int GetNumOfSinks( void)
++{
++    struct trap_sink *sink;
++	int numOf = 0;
++    for (sink = sinks; sink; sink = sink->next)
++		numOf ++;
++	return numOf;
++}
++
++
++void AddMyDataToLastSink( void * srcP, int srcLen)
++{
++	if(srcLen < sizeof(sinks->my_data))
++		memcpy( sinks->my_data, srcP, srcLen);
++}
++
++volatile int (* myBeforeSendTrapPtr)( void * my_data, netsnmp_session * sessionP, netsnmp_pdu *template_pdu) = NULL;
++
++volatile oid myEnterpriseOid[50];
++volatile int myEnterpriseOidLen = 0;
++
++// End Alan add
+ 
+ void
+ init_traps(void)
+@@ -835,6 +865,12 @@
+     in_addr_t             *pdu_in_addr_t;
+     u_long                 uptime;
+     struct trap_sink *sink;
++
++// Alan add
++	enterprise = myEnterpriseOid;
++	enterprise_length = myEnterpriseOidLen;
++// End Alan add
++
+     const char            *v1trapaddress;
+     int                    res = 0;
+ 
+@@ -1025,13 +1061,30 @@
+             if (template_v1pdu &&
+                 !netsnmp_ds_get_boolean(NETSNMP_DS_LIBRARY_ID,
+                                         NETSNMP_DS_LIB_DISABLE_V1)) {
+-                send_trap_to_sess(sink->sesp, template_v1pdu);
++// Alan add
++			    int toDo = 1;
++			    if(myBeforeSendTrapPtr != NULL)
++			    	toDo = myBeforeSendTrapPtr( sink->my_data, sink->sesp, template_v1pdu);
++
++			    if(toDo != 0)
++                	send_trap_to_sess(sink->sesp, template_v1pdu);
++// End Alan add
++                //send_trap_to_sess(sink->sesp, template_v1pdu); // Alan remove
+             }
+         } else
+ #endif
+         if (template_v2pdu) {
+             template_v2pdu->command = sink->pdutype;
+-            send_trap_to_sess(sink->sesp, template_v2pdu);
++// Alan add
++
++			    int toDo = 1;
++			    if(myBeforeSendTrapPtr != NULL)
++			    	toDo = myBeforeSendTrapPtr( sink->my_data, sink->sesp, template_v2pdu);
++
++			    if(toDo != 0)
++	                send_trap_to_sess(sink->sesp, template_v2pdu);
++// End Alan add
++            // send_trap_to_sess(sink->sesp, template_v2pdu); // Alan remove
+         }
+     }
+ #ifndef NETSNMP_DISABLE_SNMPV1
+--- netsnmp-5.4.2.1_orig/agent/snmpd.c.orig	2008-08-17 23:50:55.000000000 +0300
++++ netsnmp-5.4.2.1_new/agent/snmpd.c	2012-09-09 12:41:15.250695993 +0300
+@@ -405,6 +405,14 @@
+     FILE           *PID;
+ #endif
+ 
++// Alan add
++    /* !!! DO NOT DELETE THE FOLLOWING 2 LINES !!! */ 
++    extern GetNumOfSinks(), AddMyDataToLastSink();
++    printf("%p %p %p %p %p %p %p %p\n", GetNumOfSinks, AddMyDataToLastSink,
++    		snmp_add_var, netsnmp_unregister_handler,
++    		snmp_unregister_callback, snmp_set_var_typed_integer,
++		register_readfd, unregister_readfd);
++// End Alan add
+     SOCK_STARTUP;
+ 
+ #ifndef NETSNMP_NO_SYSTEMD

--- a/package/netsnmp/0002_netsnmp-003-agent.c.patch
+++ b/package/netsnmp/0002_netsnmp-003-agent.c.patch
@@ -1,0 +1,43 @@
+--- netsnmp-5.4.2.1_orig/agent/snmp_agent.c.origin	2012-05-29 17:10:49.252730000 +0300
++++ netsnmp-5.4.2.1_new/agent/snmp_agent.c	2012-05-29 17:13:06.000000000 +0300
+@@ -34,7 +34,7 @@
+ ******************************************************************/
+ /*
+  * Portions of this file are copyrighted by:
+- * Copyright © 2003 Sun Microsystems, Inc. All rights 
++ * Copyright ? 2003 Sun Microsystems, Inc. All rights 
+  * reserved.  Use is subject to license terms specified in the 
+  * COPYING file distributed with the Net-SNMP package.
+  */
+@@ -2505,6 +2505,10 @@
+     return asp->status;
+ }
+ 
++
++void (* pre_call_handle_var_requests)( netsnmp_agent_session *asp) = NULL;
++void (* post_call_handle_var_requests)( netsnmp_agent_session *asp) = NULL;
++
+ int
+ handle_var_requests(netsnmp_agent_session *asp)
+ {
+@@ -2515,6 +2519,9 @@
+     asp->reqinfo->asp = asp;
+     asp->reqinfo->mode = asp->mode;
+ 
++	if(pre_call_handle_var_requests != NULL)
++		pre_call_handle_var_requests(asp);
++
+     /*
+      * now, have the subtrees in the cache go search for their results 
+      */
+@@ -2588,6 +2595,10 @@
+         }
+     }
+ 
++
++	if(post_call_handle_var_requests != NULL)
++		post_call_handle_var_requests(asp);
++
+     return final_status;
+ }
+ 

--- a/package/netsnmp/0003-fix-curfilename-not-static.patch
+++ b/package/netsnmp/0003-fix-curfilename-not-static.patch
@@ -1,0 +1,11 @@
+--- netsnmp-5.9_orig/snmplib/read_config.c.origin	2022-05-29 18:30:48.190090824 +0300
++++ netsnmp-5.9_new/snmplib/read_config.c	2022-05-29 18:32:15.668226606 +0300
+@@ -473,7 +473,7 @@
+ #endif
+ 
+ static unsigned int  linecount;
+-static const char   *curfilename;
++const char   *curfilename;
+ 
+ struct config_line *
+ read_config_get_handlers(const char *type)

--- a/package/netsnmp/netsnmp.mk
+++ b/package/netsnmp/netsnmp.mk
@@ -41,6 +41,10 @@ NETSNMP_INSTALL_TARGET_OPTS = DESTDIR=$(TARGET_DIR) LIB_LDCONFIG_CMD=true instal
 NETSNMP_MAKE = $(MAKE1)
 NETSNMP_CONFIG_SCRIPTS = net-snmp-config
 NETSNMP_AUTORECONF = YES
+WITH_OUT_MIB_MODULES:="mibII/snmp_mib, mibII/system_mib, mibII/sysORTable"
+WITH_MIB_MODULES:="ucd-snmp/dlmod agentx"
+NET_SNMP_PERSISTENT_DIR:=/var
+TARGET_CFLAGS = -DNETSNMP_NO_INLINE
 
 ifeq ($(BR2_ENDIAN),"BIG")
 NETSNMP_CONF_OPTS += --with-endianness=big
@@ -82,6 +86,34 @@ endif
 ifneq ($(BR2_PACKAGE_NETSNMP_ENABLE_MIBS),y)
 NETSNMP_CONF_OPTS += --disable-mib-loading
 NETSNMP_CONF_OPTS += --disable-mibs
+NETSNMP_CONF_OPTS += --silent
+NETSNMP_CONF_OPTS += --enable-agent
+NETSNMP_CONF_OPTS += --disable-manuals
+NETSNMP_CONF_OPTS += --enable-as-needed
+NETSNMP_CONF_OPTS += --disable-scripts
+NETSNMP_CONF_OPTS += --enable-ipv6
+NETSNMP_CONF_OPTS += --disable-embedded-perl
+NETSNMP_CONF_OPTS += --disable-perl-cc-checks
+NETSNMP_CONF_OPTS += --with-transports="UDPIPv6 TCPIPv6"
+NETSNMP_CONF_OPTS += --with-out-transports="AAL5PVC IPX"
+NETSNMP_CONF_OPTS += --without-rpm
+NETSNMP_CONF_OPTS += --enable-mini-agent
+NETSNMP_CONF_OPTS += --disable-mib-loading
+NETSNMP_CONF_OPTS += --with-sys-contact=root@
+NETSNMP_CONF_OPTS += --with-sys-location=unknown
+NETSNMP_CONF_OPTS += --with-logfile=none
+NETSNMP_CONF_OPTS += --with-perl-modules=no
+NETSNMP_CONF_OPTS += --with-default-snmp-version=2
+NETSNMP_CONF_OPTS += --with-out-mib-modules=${WITH_OUT_MIB_MODULES}
+NETSNMP_CONF_OPTS += --with-mib-modules=${WITH_MIB_MODULES}
+NETSNMP_CONF_OPTS += --with-persistent-directory=${NET_SNMP_PERSISTENT_DIR}
+NETSNMP_CONF_OPTS += --enable-shared
+NETSNMP_CONF_OPTS += --disable-static
+NETSNMP_CONF_OPTS += --with-enterprise-sysoid=1.3.6.1.4.1.31926
+NETSNMP_CONF_OPTS += --with-enterprise-notification-oid=1.3.6.1.4.1.31926
+NETSNMP_CONF_OPTS += --with-enterprise-oid=31926
+NETSNMP_CONF_OPTS += --with-gnu-ld
+NETSNMP_CONF_OPTS += --with-cflags=${TARGET_CFLAGS}
 endif
 
 ifneq ($(BR2_PACKAGE_NETSNMP_ENABLE_DEBUGGING),y)

--- a/package/netsnmp/netsnmp.mk
+++ b/package/netsnmp/netsnmp.mk
@@ -138,5 +138,23 @@ define NETSNMP_INSTALL_INIT_SYSV
 		$(TARGET_DIR)/etc/init.d/S59snmpd
 endef
 endif
+define NETSNMP_STAGING_NETSNMP_CONFIG_FIXUP
+	$(SED) "s,^prefix=.*,prefix=\'$(STAGING_DIR)/usr\',g" \
+		-e "s,^exec_prefix=.*,exec_prefix=\'$(STAGING_DIR)/usr\',g" \
+		-e "s,^includedir=.*,includedir=\'$(STAGING_DIR)/usr/include\',g" \
+		-e "s,^libdir=.*,libdir=\'$(STAGING_DIR)/usr/lib\',g" \
+		$(STAGING_DIR)/usr/bin/net-snmp-config
+endef
+
+define NETSNMP_POST_PATCH_FIXUP
+	echo " ============ Patch net-snmp-config.h file after configure ============="
+	$(SED) 's;#define STRUCT_NLIST_HAS_N_VALUE 1;/* #undef STRUCT_NLIST_HAS_N_VALUE */;g' $(@D)/include/net-snmp/net-snmp-config.h
+	$(SED) 's;#define HAVE_NLIST_H 1;/* #undef HAVE_NLIST_H */;g' $(@D)/include/net-snmp/net-snmp-config.h
+	echo " ================= DONE ================"
+endef
+
+NETSNMP_POST_CONFIGURE_HOOKS += NETSNMP_POST_PATCH_FIXUP
+
+NETSNMP_POST_INSTALL_STAGING_HOOKS += NETSNMP_STAGING_NETSNMP_CONFIG_FIXUP
 
 $(eval $(autotools-package))


### PR DESCRIPTION
The patches are imported from the portfolio master branch which built net-snmp version. 5.4.2.1,
except for 0003-fix-curfilename-not-static.patch, which is new.