### PR TITLE
Remove 'ERROR:' string from the build log

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -766,9 +766,9 @@ endif
 	$(STRIP_FIND_CMD) | xargs -0 $(STRIPCMD) 2>/dev/null || true
 	$(STRIP_FIND_SPECIAL_LIBS_CMD) | xargs -0 -r $(STRIPCMD) $(STRIP_STRIP_DEBUG) 2>/dev/null || true
 
-	test -f $(TARGET_DIR)/etc/ld.so.conf && \
+	@test -f $(TARGET_DIR)/etc/ld.so.conf && \
 		{ echo "ERROR: we shouldn't have a /etc/ld.so.conf file"; exit 1; } || true
-	test -d $(TARGET_DIR)/etc/ld.so.conf.d && \
+	@test -d $(TARGET_DIR)/etc/ld.so.conf.d && \
 		{ echo "ERROR: we shouldn't have a /etc/ld.so.conf.d directory"; exit 1; } || true
 	mkdir -p $(TARGET_DIR)/etc
 	( \


### PR DESCRIPTION
Remove the `ERROR:` line from the build log
Tested locally.
Reference: PORTF-1163