### PR TITLE
Use original umask for dl-cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,13 +68,14 @@ endif
 CANONICAL_CURDIR = $(realpath $(CURDIR))
 
 REQ_UMASK = 0022
+CUR_UMASK := $(shell umask)
 
 # Make sure O= is passed (with its absolute canonical path) everywhere the
 # toplevel makefile is called back.
 EXTRAMAKEARGS := O=$(CANONICAL_O)
 
 # Check Buildroot execution pre-requisites here.
-ifneq ($(shell umask):$(CURDIR):$(O),$(REQ_UMASK):$(CANONICAL_CURDIR):$(CANONICAL_O))
+ifneq ($(CUR_UMASK):$(CURDIR):$(O),$(REQ_UMASK):$(CANONICAL_CURDIR):$(CANONICAL_O))
 .PHONY: _all $(MAKECMDGOALS)
 
 $(MAKECMDGOALS): _all
@@ -83,6 +84,7 @@ $(MAKECMDGOALS): _all
 _all:
 	@umask $(REQ_UMASK) && \
 		$(MAKE) -C $(CANONICAL_CURDIR) --no-print-directory \
+			BR_ORIG_UMASK=$(CUR_UMASK) \
 			$(MAKECMDGOALS) $(EXTRAMAKEARGS)
 
 else # umask / $(CURDIR) / $(O)

--- a/package/pkg-download.mk
+++ b/package/pkg-download.mk
@@ -105,9 +105,15 @@ endif
 #
 ################################################################################
 
+# Restore the user's original umask during the whole download, in case he has
+# provisions set to share the download directory with his group (or others).
+ifneq ($(BR_ORIG_UMASK),)
+DOWNLOAD_SET_UMASK = umask $(BR_ORIG_UMASK);
+endif
+
 define DOWNLOAD
-	$(Q)mkdir -p $($(2)_DL_DIR)
-	$(Q)$(EXTRA_ENV) $($(2)_DL_ENV) \
+		$(Q)$(DOWNLOAD_SET_UMASK) mkdir -p $($(PKG)_DL_DIR)
+		$(Q)$(DOWNLOAD_SET_UMASK) $(EXTRA_ENV) $($(2)_DL_ENV) \
 		flock $($(2)_DL_DIR)/.lock $(DL_WRAPPER) \
 		-c '$($(2)_DL_VERSION)' \
 		-d '$($(2)_DL_DIR)' \


### PR DESCRIPTION
This is cherry-pick of the upstream commit  https://github.com/buildroot/buildroot/commit/e9960267e6208423b4656a152b3e576b4e5bd027

package/pkg-download: restore user's original umask for the whole download process Root makefile imposes 'umask 0022', and this may be more restrictive than the user's original umask - which could have provisions set to share files/dirs with other users.
As an example, the imposed value makes the per-package download directories not writeable for the group, but just for the owner - the user that issued the first build that populated the per-package dl dir for the first time (say user A). Thus, if a BR package changes its version (e.g. for buildroot update), and another user (say user B, in the same group of A) starts a build, BR fails the creation of package-xxx.tar.gz inside the dl dir, because user B has no write permissions on that path. Furthermore, in the case of the git backend, this makes the git cache not updatable by a different user. This is disruptive for a host used by many users, all belonging to a certain group.

So, to allow sharing of a rw BR2_DL_DIR location among users, we save the original umask value and restore it during the download process.


[Arnout:
 - CURR_UMASK -> CUR_UMASK.
 - BR2_ORIG_UMASK -> BR_ORIG_UMASK.
 - Don't check if the umask is more permissive, apply it regardless. If the user explicitly doesn't want to make their DL_DIR readable by others, that's fine.
 - Don't export BR_ORIG_UMASK.
 - Only set BR_ORIG_UMASK if it we recurse, and only set umask if BR_ORIG_UMASK is set.
 - Add DOWNLOAD_SET_UMASK to simplify the latter. ]